### PR TITLE
Tt 181 disable evc for intersection 421

### DIFF
--- a/xil-Town05/cdasim_config/evc_sumo/evc_sumo_cfg.json
+++ b/xil-Town05/cdasim_config/evc_sumo/evc_sumo_cfg.json
@@ -1,25 +1,7 @@
 {
   "controllers": [
-
-
-       {
-      "controllerId": 1,
-      "controllerCfgPath": "/home/carma/src/resources/421.cfg",
-      "moe_dir": null,
-      "start_time": 0,
-      "bind_ip": null,
-      "web_port": 0,
-      "snmp_port": 5050,
-      "harness_port": 0,
-      "sumoTlId": 421,
-      "enableWebPanel": true,
-      "evcPhases": [{"evcPhaseId": 2, "sumoTlStateIndex":[4,5,6,7]},
-                      {"evcPhaseId": 4, "sumoTlStateIndex":[8,9,10,11]},
-                      {"evcPhaseId": 6, "sumoTlStateIndex":[12,13,14,15]},
-                      {"evcPhaseId": 8, "sumoTlStateIndex":[0,1,2,3]}]
-      },
       {
-      "controllerId": 2,
+      "controllerId": 1,
       "controllerCfgPath": "/home/carma/src/resources/965_mmitss_binaryntcip.cfg",
       "moe_dir": null,
       "start_time": 0,
@@ -36,7 +18,7 @@
       },
 
       {
-      "controllerId": 3,
+      "controllerId": 2,
       "controllerCfgPath": "/home/carma/src/resources/829.cfg",
       "moe_dir": null,
       "start_time": 0,

--- a/xil-Town05/cdasim_config/sumo_background_traffic/Town05.net.xml
+++ b/xil-Town05/cdasim_config/sumo_background_traffic/Town05.net.xml
@@ -1434,7 +1434,7 @@
     </edge>
 
     <tlLogic id="421" type="static" programID="0" offset="0">
-        <phase duration="42" state="ggggrrrrggggrrrr"/>
+        <phase duration="42" state="rrrrggggrrrrgggg"/>
         <param key="linkSignalID:0" value="2386"/>
         <param key="linkSignalID:1" value="2386"/>
         <param key="linkSignalID:10" value="2388"/>


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->

This PR enables SUMO to resume traffic light control at intersection ID 421, previously managed by EVC. By removing the part of the configuration in evc_sumo_config.json as the change in this PR, the traffic light state will revert to the tlLogic defined in SUMO's .net.xml, currently set to a constant green phase for east-west traffic

## Related Issue
TT-181
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.