### PR TITLE
Update to most recent logging paradigm

### DIFF
--- a/carla_ground_truth_integration/carma_rosconsole.conf
+++ b/carla_ground_truth_integration/carma_rosconsole.conf
@@ -3,7 +3,7 @@ ros=WARN
 roscpp.superdebug=WARN
 
 # Set package specific log level
-# Syntax is <my package name>=< Log level>
+# Syntax is <my node name>=< Log level>
 # Log levels
 # DEBUG	Detailed logs useful for debugging
 # INFO	Useful logs for understanding system events
@@ -28,16 +28,17 @@ roscpp.superdebug=WARN
 # * Changes here require restarting the affected process(es) -- levels are
 #   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
 
-mpc_follower=INFO
 as=WARN
-waypoint_generator=INFO
-route=INFO
-mpc_follower_wrapper=INFO
+route_node=INFO
 carma_wm=INFO
+basic_autonomy=WARN
 arbitrator=WARN
-trajectory_executor=INFO
+trajectory_executor_node=INFO
 plan_delegator=WARN
 inlanecruising_plugin=INFO
+cooperative_lanechange=INFO
+lci_strategic_plugin=INFO
+light_controlled_intersection_tactical_plugin=INFO
 route_following_plugin=INFO
 pure_pursuit_wrapper=INFO
 system_controller=INFO

--- a/carla_ground_truth_integration/carma_rosconsole.conf
+++ b/carla_ground_truth_integration/carma_rosconsole.conf
@@ -1,26 +1,44 @@
 # Set the default ros output level
-log4j.logger.ros=WARN
-log4j.logger.ros.roscpp.superdebug=WARN
+ros=WARN
+roscpp.superdebug=WARN
 
 # Set package specific log level
-# Syntax is log4j.logger.ros.< my package name>=< Log level>
+# Syntax is <my package name>=< Log level>
 # Log levels
 # DEBUG	Detailed logs useful for debugging
 # INFO	Useful logs for understanding system events
 # WARN	Warning notifications that represent problems but will not severly degrade system operation
 # ERROR	Error notifications that severly degrade system operation, but the system might still be able to operate
 # FATAL	Error notification that the system cannot recover from
-log4j.logger.ros.mpc_follower=INFO
-log4j.logger.ros.as=WARN
-log4j.logger.ros.waypoint_generator=INFO
-log4j.logger.ros.route=INFO
-log4j.logger.ros.mpc_follower_wrapper=INFO
-log4j.logger.ros.carma_wm=INFO
-log4j.logger.ros.arbitrator=WARN
-log4j.logger.ros.trajectory_executor=INFO
-log4j.logger.ros.plan_delegator=WARN
-log4j.logger.ros.inlanecruising_plugin=INFO
-log4j.logger.ros.route_following_plugin=INFO
-log4j.logger.ros.pure_pursuit_wrapper=INFO
-log4j.logger.ros.system_controller=INFO
-log4j.logger.ros.subsystem_controllers=INFO
+#
+# Advanced usage notes:
+# * Both the node name or the dot separated, full namespace name works:
+#   - yield_plugin=DEBUG
+#   - guidance.plugins.yield_plugin=DEBUG
+# * Library loggers also work (which applies to all plugins that link to that library):
+#   - carma_wm=DEBUG
+#   - basic_autonomy=DEBUG
+# * Library loggers can also be scoped to a specific plugin (which applies to only that plugin):
+#   - yield_plugin.carma_wm=DEBUG
+#   ... would only affect the yield_plugin's carma_wm logger, not any other plugin's carma_wm.
+# * A node's own level cascades to its child loggers (yield_plugin=DEBUG also
+#   raises yield_plugin.carma_wm) unless a more specific key overrides it.
+# * A key that doesn't exactly match a real logger name (wrong namespace,
+#   typo, wrong pluralization) fails silently -- no error is printed.
+# * Changes here require restarting the affected process(es) -- levels are
+#   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
+
+mpc_follower=INFO
+as=WARN
+waypoint_generator=INFO
+route=INFO
+mpc_follower_wrapper=INFO
+carma_wm=INFO
+arbitrator=WARN
+trajectory_executor=INFO
+plan_delegator=WARN
+inlanecruising_plugin=INFO
+route_following_plugin=INFO
+pure_pursuit_wrapper=INFO
+system_controller=INFO
+subsystem_controllers=INFO

--- a/development/carma_rosconsole.conf
+++ b/development/carma_rosconsole.conf
@@ -3,7 +3,7 @@ ros=WARN
 roscpp.superdebug=WARN
 
 # Set package specific log level
-# Syntax is <my package name>=< Log level>
+# Syntax is <my node name>=< Log level>
 # Log levels
 # DEBUG	Detailed logs useful for debugging
 # INFO	Useful logs for understanding system events
@@ -28,16 +28,17 @@ roscpp.superdebug=WARN
 # * Changes here require restarting the affected process(es) -- levels are
 #   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
 
-mpc_follower=INFO
 as=WARN
-waypoint_generator=INFO
-route=INFO
-mpc_follower_wrapper=INFO
+route_node=INFO
 carma_wm=INFO
+basic_autonomy=WARN
 arbitrator=WARN
-trajectory_executor=INFO
+trajectory_executor_node=INFO
 plan_delegator=WARN
 inlanecruising_plugin=INFO
+cooperative_lanechange=INFO
+lci_strategic_plugin=INFO
+light_controlled_intersection_tactical_plugin=INFO
 route_following_plugin=INFO
 pure_pursuit_wrapper=INFO
 system_controller=INFO

--- a/development/carma_rosconsole.conf
+++ b/development/carma_rosconsole.conf
@@ -1,26 +1,44 @@
 # Set the default ros output level
-log4j.logger.ros=WARN
-log4j.logger.ros.roscpp.superdebug=WARN
+ros=WARN
+roscpp.superdebug=WARN
 
 # Set package specific log level
-# Syntax is log4j.logger.ros.< my package name>=< Log level>
+# Syntax is <my package name>=< Log level>
 # Log levels
 # DEBUG	Detailed logs useful for debugging
 # INFO	Useful logs for understanding system events
 # WARN	Warning notifications that represent problems but will not severly degrade system operation
 # ERROR	Error notifications that severly degrade system operation, but the system might still be able to operate
 # FATAL	Error notification that the system cannot recover from
-log4j.logger.ros.mpc_follower=INFO
-log4j.logger.ros.as=WARN
-log4j.logger.ros.waypoint_generator=INFO
-log4j.logger.ros.route=INFO
-log4j.logger.ros.mpc_follower_wrapper=INFO
-log4j.logger.ros.carma_wm=INFO
-log4j.logger.ros.arbitrator=WARN
-log4j.logger.ros.trajectory_executor=INFO
-log4j.logger.ros.plan_delegator=WARN
-log4j.logger.ros.inlanecruising_plugin=INFO
-log4j.logger.ros.route_following_plugin=INFO
-log4j.logger.ros.pure_pursuit_wrapper=INFO
-log4j.logger.ros.system_controller=INFO
-log4j.logger.ros.subsystem_controllers=INFO
+#
+# Advanced usage notes:
+# * Both the node name or the dot separated, full namespace name works:
+#   - yield_plugin=DEBUG
+#   - guidance.plugins.yield_plugin=DEBUG
+# * Library loggers also work (which applies to all plugins that link to that library):
+#   - carma_wm=DEBUG
+#   - basic_autonomy=DEBUG
+# * Library loggers can also be scoped to a specific plugin (which applies to only that plugin):
+#   - yield_plugin.carma_wm=DEBUG
+#   ... would only affect the yield_plugin's carma_wm logger, not any other plugin's carma_wm.
+# * A node's own level cascades to its child loggers (yield_plugin=DEBUG also
+#   raises yield_plugin.carma_wm) unless a more specific key overrides it.
+# * A key that doesn't exactly match a real logger name (wrong namespace,
+#   typo, wrong pluralization) fails silently -- no error is printed.
+# * Changes here require restarting the affected process(es) -- levels are
+#   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
+
+mpc_follower=INFO
+as=WARN
+waypoint_generator=INFO
+route=INFO
+mpc_follower_wrapper=INFO
+carma_wm=INFO
+arbitrator=WARN
+trajectory_executor=INFO
+plan_delegator=WARN
+inlanecruising_plugin=INFO
+route_following_plugin=INFO
+pure_pursuit_wrapper=INFO
+system_controller=INFO
+subsystem_controllers=INFO

--- a/xil-Town04/carma_rosconsole.conf
+++ b/xil-Town04/carma_rosconsole.conf
@@ -3,7 +3,7 @@ ros=WARN
 roscpp.superdebug=WARN
 
 # Set package specific log level
-# Syntax is <my package name>=< Log level>
+# Syntax is <my node name>=< Log level>
 # Log levels
 # DEBUG	Detailed logs useful for debugging
 # INFO	Useful logs for understanding system events
@@ -28,16 +28,17 @@ roscpp.superdebug=WARN
 # * Changes here require restarting the affected process(es) -- levels are
 #   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
 
-mpc_follower=INFO
 as=WARN
-waypoint_generator=INFO
-route=INFO
-mpc_follower_wrapper=INFO
+route_node=INFO
 carma_wm=INFO
+basic_autonomy=WARN
 arbitrator=WARN
-trajectory_executor=INFO
+trajectory_executor_node=INFO
 plan_delegator=WARN
 inlanecruising_plugin=INFO
+cooperative_lanechange=INFO
+lci_strategic_plugin=INFO
+light_controlled_intersection_tactical_plugin=INFO
 route_following_plugin=INFO
 pure_pursuit_wrapper=INFO
 system_controller=INFO

--- a/xil-Town04/carma_rosconsole.conf
+++ b/xil-Town04/carma_rosconsole.conf
@@ -1,26 +1,44 @@
 # Set the default ros output level
-log4j.logger.ros=WARN
-log4j.logger.ros.roscpp.superdebug=WARN
+ros=WARN
+roscpp.superdebug=WARN
 
 # Set package specific log level
-# Syntax is log4j.logger.ros.< my package name>=< Log level>
+# Syntax is <my package name>=< Log level>
 # Log levels
 # DEBUG	Detailed logs useful for debugging
 # INFO	Useful logs for understanding system events
 # WARN	Warning notifications that represent problems but will not severly degrade system operation
 # ERROR	Error notifications that severly degrade system operation, but the system might still be able to operate
 # FATAL	Error notification that the system cannot recover from
-log4j.logger.ros.mpc_follower=INFO
-log4j.logger.ros.as=WARN
-log4j.logger.ros.waypoint_generator=INFO
-log4j.logger.ros.route=INFO
-log4j.logger.ros.mpc_follower_wrapper=INFO
-log4j.logger.ros.carma_wm=INFO
-log4j.logger.ros.arbitrator=WARN
-log4j.logger.ros.trajectory_executor=INFO
-log4j.logger.ros.plan_delegator=WARN
-log4j.logger.ros.inlanecruising_plugin=INFO
-log4j.logger.ros.route_following_plugin=INFO
-log4j.logger.ros.pure_pursuit_wrapper=INFO
-log4j.logger.ros.system_controller=INFO
-log4j.logger.ros.subsystem_controllers=INFO
+#
+# Advanced usage notes:
+# * Both the node name or the dot separated, full namespace name works:
+#   - yield_plugin=DEBUG
+#   - guidance.plugins.yield_plugin=DEBUG
+# * Library loggers also work (which applies to all plugins that link to that library):
+#   - carma_wm=DEBUG
+#   - basic_autonomy=DEBUG
+# * Library loggers can also be scoped to a specific plugin (which applies to only that plugin):
+#   - yield_plugin.carma_wm=DEBUG
+#   ... would only affect the yield_plugin's carma_wm logger, not any other plugin's carma_wm.
+# * A node's own level cascades to its child loggers (yield_plugin=DEBUG also
+#   raises yield_plugin.carma_wm) unless a more specific key overrides it.
+# * A key that doesn't exactly match a real logger name (wrong namespace,
+#   typo, wrong pluralization) fails silently -- no error is printed.
+# * Changes here require restarting the affected process(es) -- levels are
+#   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
+
+mpc_follower=INFO
+as=WARN
+waypoint_generator=INFO
+route=INFO
+mpc_follower_wrapper=INFO
+carma_wm=INFO
+arbitrator=WARN
+trajectory_executor=INFO
+plan_delegator=WARN
+inlanecruising_plugin=INFO
+route_following_plugin=INFO
+pure_pursuit_wrapper=INFO
+system_controller=INFO
+subsystem_controllers=INFO

--- a/xil-Town05/carma_rosconsole.conf
+++ b/xil-Town05/carma_rosconsole.conf
@@ -3,7 +3,7 @@ ros=WARN
 roscpp.superdebug=WARN
 
 # Set package specific log level
-# Syntax is <my package name>=< Log level>
+# Syntax is <my node name>=< Log level>
 # Log levels
 # DEBUG	Detailed logs useful for debugging
 # INFO	Useful logs for understanding system events
@@ -28,16 +28,17 @@ roscpp.superdebug=WARN
 # * Changes here require restarting the affected process(es) -- levels are
 #   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
 
-mpc_follower=INFO
 as=WARN
-waypoint_generator=INFO
-route=INFO
-mpc_follower_wrapper=INFO
+route_node=INFO
 carma_wm=INFO
+basic_autonomy=WARN
 arbitrator=WARN
-trajectory_executor=INFO
+trajectory_executor_node=INFO
 plan_delegator=WARN
 inlanecruising_plugin=INFO
+cooperative_lanechange=INFO
+lci_strategic_plugin=INFO
+light_controlled_intersection_tactical_plugin=INFO
 route_following_plugin=INFO
 pure_pursuit_wrapper=INFO
 system_controller=INFO

--- a/xil-Town05/carma_rosconsole.conf
+++ b/xil-Town05/carma_rosconsole.conf
@@ -1,26 +1,44 @@
 # Set the default ros output level
-log4j.logger.ros=WARN
-log4j.logger.ros.roscpp.superdebug=WARN
+ros=WARN
+roscpp.superdebug=WARN
 
 # Set package specific log level
-# Syntax is log4j.logger.ros.< my package name>=< Log level>
+# Syntax is <my package name>=< Log level>
 # Log levels
 # DEBUG	Detailed logs useful for debugging
 # INFO	Useful logs for understanding system events
 # WARN	Warning notifications that represent problems but will not severly degrade system operation
 # ERROR	Error notifications that severly degrade system operation, but the system might still be able to operate
 # FATAL	Error notification that the system cannot recover from
-log4j.logger.ros.mpc_follower=INFO
-log4j.logger.ros.as=WARN
-log4j.logger.ros.waypoint_generator=INFO
-log4j.logger.ros.route=INFO
-log4j.logger.ros.mpc_follower_wrapper=INFO
-log4j.logger.ros.carma_wm=INFO
-log4j.logger.ros.arbitrator=WARN
-log4j.logger.ros.trajectory_executor=INFO
-log4j.logger.ros.plan_delegator=WARN
-log4j.logger.ros.inlanecruising_plugin=INFO
-log4j.logger.ros.route_following_plugin=INFO
-log4j.logger.ros.pure_pursuit_wrapper=INFO
-log4j.logger.ros.system_controller=INFO
-log4j.logger.ros.subsystem_controllers=INFO
+#
+# Advanced usage notes:
+# * Both the node name or the dot separated, full namespace name works:
+#   - yield_plugin=DEBUG
+#   - guidance.plugins.yield_plugin=DEBUG
+# * Library loggers also work (which applies to all plugins that link to that library):
+#   - carma_wm=DEBUG
+#   - basic_autonomy=DEBUG
+# * Library loggers can also be scoped to a specific plugin (which applies to only that plugin):
+#   - yield_plugin.carma_wm=DEBUG
+#   ... would only affect the yield_plugin's carma_wm logger, not any other plugin's carma_wm.
+# * A node's own level cascades to its child loggers (yield_plugin=DEBUG also
+#   raises yield_plugin.carma_wm) unless a more specific key overrides it.
+# * A key that doesn't exactly match a real logger name (wrong namespace,
+#   typo, wrong pluralization) fails silently -- no error is printed.
+# * Changes here require restarting the affected process(es) -- levels are
+#   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
+
+mpc_follower=INFO
+as=WARN
+waypoint_generator=INFO
+route=INFO
+mpc_follower_wrapper=INFO
+carma_wm=INFO
+arbitrator=WARN
+trajectory_executor=INFO
+plan_delegator=WARN
+inlanecruising_plugin=INFO
+route_following_plugin=INFO
+pure_pursuit_wrapper=INFO
+system_controller=INFO
+subsystem_controllers=INFO

--- a/xil-Town10/carma_rosconsole.conf
+++ b/xil-Town10/carma_rosconsole.conf
@@ -3,7 +3,7 @@ ros=WARN
 roscpp.superdebug=WARN
 
 # Set package specific log level
-# Syntax is <my package name>=< Log level>
+# Syntax is <my node name>=< Log level>
 # Log levels
 # DEBUG	Detailed logs useful for debugging
 # INFO	Useful logs for understanding system events
@@ -28,16 +28,17 @@ roscpp.superdebug=WARN
 # * Changes here require restarting the affected process(es) -- levels are
 #   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
 
-mpc_follower=INFO
 as=WARN
-waypoint_generator=INFO
-route=INFO
-mpc_follower_wrapper=INFO
+route_node=INFO
 carma_wm=INFO
+basic_autonomy=WARN
 arbitrator=WARN
-trajectory_executor=INFO
+trajectory_executor_node=INFO
 plan_delegator=WARN
 inlanecruising_plugin=INFO
+cooperative_lanechange=INFO
+lci_strategic_plugin=INFO
+light_controlled_intersection_tactical_plugin=INFO
 route_following_plugin=INFO
 pure_pursuit_wrapper=INFO
 system_controller=INFO

--- a/xil-Town10/carma_rosconsole.conf
+++ b/xil-Town10/carma_rosconsole.conf
@@ -1,26 +1,44 @@
 # Set the default ros output level
-log4j.logger.ros=WARN
-log4j.logger.ros.roscpp.superdebug=WARN
+ros=WARN
+roscpp.superdebug=WARN
 
 # Set package specific log level
-# Syntax is log4j.logger.ros.< my package name>=< Log level>
+# Syntax is <my package name>=< Log level>
 # Log levels
 # DEBUG	Detailed logs useful for debugging
 # INFO	Useful logs for understanding system events
 # WARN	Warning notifications that represent problems but will not severly degrade system operation
 # ERROR	Error notifications that severly degrade system operation, but the system might still be able to operate
 # FATAL	Error notification that the system cannot recover from
-log4j.logger.ros.mpc_follower=INFO
-log4j.logger.ros.as=WARN
-log4j.logger.ros.waypoint_generator=INFO
-log4j.logger.ros.route=INFO
-log4j.logger.ros.mpc_follower_wrapper=INFO
-log4j.logger.ros.carma_wm=INFO
-log4j.logger.ros.arbitrator=WARN
-log4j.logger.ros.trajectory_executor=INFO
-log4j.logger.ros.plan_delegator=WARN
-log4j.logger.ros.inlanecruising_plugin=INFO
-log4j.logger.ros.route_following_plugin=INFO
-log4j.logger.ros.pure_pursuit_wrapper=INFO
-log4j.logger.ros.system_controller=INFO
-log4j.logger.ros.subsystem_controllers=INFO
+#
+# Advanced usage notes:
+# * Both the node name or the dot separated, full namespace name works:
+#   - yield_plugin=DEBUG
+#   - guidance.plugins.yield_plugin=DEBUG
+# * Library loggers also work (which applies to all plugins that link to that library):
+#   - carma_wm=DEBUG
+#   - basic_autonomy=DEBUG
+# * Library loggers can also be scoped to a specific plugin (which applies to only that plugin):
+#   - yield_plugin.carma_wm=DEBUG
+#   ... would only affect the yield_plugin's carma_wm logger, not any other plugin's carma_wm.
+# * A node's own level cascades to its child loggers (yield_plugin=DEBUG also
+#   raises yield_plugin.carma_wm) unless a more specific key overrides it.
+# * A key that doesn't exactly match a real logger name (wrong namespace,
+#   typo, wrong pluralization) fails silently -- no error is printed.
+# * Changes here require restarting the affected process(es) -- levels are
+#   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
+
+mpc_follower=INFO
+as=WARN
+waypoint_generator=INFO
+route=INFO
+mpc_follower_wrapper=INFO
+carma_wm=INFO
+arbitrator=WARN
+trajectory_executor=INFO
+plan_delegator=WARN
+inlanecruising_plugin=INFO
+route_following_plugin=INFO
+pure_pursuit_wrapper=INFO
+system_controller=INFO
+subsystem_controllers=INFO

--- a/xil_carma_basic_lanefollow_scenario/carma_rosconsole.conf
+++ b/xil_carma_basic_lanefollow_scenario/carma_rosconsole.conf
@@ -3,7 +3,7 @@ ros=WARN
 roscpp.superdebug=WARN
 
 # Set package specific log level
-# Syntax is <my package name>=< Log level>
+# Syntax is <my node name>=< Log level>
 # Log levels
 # DEBUG	Detailed logs useful for debugging
 # INFO	Useful logs for understanding system events
@@ -28,16 +28,17 @@ roscpp.superdebug=WARN
 # * Changes here require restarting the affected process(es) -- levels are
 #   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
 
-mpc_follower=INFO
 as=WARN
-waypoint_generator=INFO
-route=INFO
-mpc_follower_wrapper=INFO
+route_node=INFO
 carma_wm=INFO
+basic_autonomy=WARN
 arbitrator=WARN
-trajectory_executor=INFO
+trajectory_executor_node=INFO
 plan_delegator=WARN
 inlanecruising_plugin=INFO
+cooperative_lanechange=INFO
+lci_strategic_plugin=INFO
+light_controlled_intersection_tactical_plugin=INFO
 route_following_plugin=INFO
 pure_pursuit_wrapper=INFO
 system_controller=INFO

--- a/xil_carma_basic_lanefollow_scenario/carma_rosconsole.conf
+++ b/xil_carma_basic_lanefollow_scenario/carma_rosconsole.conf
@@ -1,26 +1,44 @@
 # Set the default ros output level
-log4j.logger.ros=WARN
-log4j.logger.ros.roscpp.superdebug=WARN
+ros=WARN
+roscpp.superdebug=WARN
 
 # Set package specific log level
-# Syntax is log4j.logger.ros.< my package name>=< Log level>
+# Syntax is <my package name>=< Log level>
 # Log levels
 # DEBUG	Detailed logs useful for debugging
 # INFO	Useful logs for understanding system events
 # WARN	Warning notifications that represent problems but will not severly degrade system operation
 # ERROR	Error notifications that severly degrade system operation, but the system might still be able to operate
 # FATAL	Error notification that the system cannot recover from
-log4j.logger.ros.mpc_follower=INFO
-log4j.logger.ros.as=WARN
-log4j.logger.ros.waypoint_generator=INFO
-log4j.logger.ros.route=INFO
-log4j.logger.ros.mpc_follower_wrapper=INFO
-log4j.logger.ros.carma_wm=INFO
-log4j.logger.ros.arbitrator=WARN
-log4j.logger.ros.trajectory_executor=INFO
-log4j.logger.ros.plan_delegator=WARN
-log4j.logger.ros.inlanecruising_plugin=INFO
-log4j.logger.ros.route_following_plugin=INFO
-log4j.logger.ros.pure_pursuit_wrapper=INFO
-log4j.logger.ros.system_controller=INFO
-log4j.logger.ros.subsystem_controllers=INFO
+#
+# Advanced usage notes:
+# * Both the node name or the dot separated, full namespace name works:
+#   - yield_plugin=DEBUG
+#   - guidance.plugins.yield_plugin=DEBUG
+# * Library loggers also work (which applies to all plugins that link to that library):
+#   - carma_wm=DEBUG
+#   - basic_autonomy=DEBUG
+# * Library loggers can also be scoped to a specific plugin (which applies to only that plugin):
+#   - yield_plugin.carma_wm=DEBUG
+#   ... would only affect the yield_plugin's carma_wm logger, not any other plugin's carma_wm.
+# * A node's own level cascades to its child loggers (yield_plugin=DEBUG also
+#   raises yield_plugin.carma_wm) unless a more specific key overrides it.
+# * A key that doesn't exactly match a real logger name (wrong namespace,
+#   typo, wrong pluralization) fails silently -- no error is printed.
+# * Changes here require restarting the affected process(es) -- levels are
+#   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
+
+mpc_follower=INFO
+as=WARN
+waypoint_generator=INFO
+route=INFO
+mpc_follower_wrapper=INFO
+carma_wm=INFO
+arbitrator=WARN
+trajectory_executor=INFO
+plan_delegator=WARN
+inlanecruising_plugin=INFO
+route_following_plugin=INFO
+pure_pursuit_wrapper=INFO
+system_controller=INFO
+subsystem_controllers=INFO

--- a/xil_carma_cloud/carma_rosconsole.conf
+++ b/xil_carma_cloud/carma_rosconsole.conf
@@ -3,7 +3,7 @@ ros=WARN
 roscpp.superdebug=WARN
 
 # Set package specific log level
-# Syntax is <my package name>=< Log level>
+# Syntax is <my node name>=< Log level>
 # Log levels
 # DEBUG	Detailed logs useful for debugging
 # INFO	Useful logs for understanding system events
@@ -28,16 +28,17 @@ roscpp.superdebug=WARN
 # * Changes here require restarting the affected process(es) -- levels are
 #   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
 
-mpc_follower=INFO
 as=WARN
-waypoint_generator=INFO
-route=INFO
-mpc_follower_wrapper=INFO
+route_node=INFO
 carma_wm=INFO
+basic_autonomy=WARN
 arbitrator=WARN
-trajectory_executor=INFO
+trajectory_executor_node=INFO
 plan_delegator=WARN
 inlanecruising_plugin=INFO
+cooperative_lanechange=INFO
+lci_strategic_plugin=INFO
+light_controlled_intersection_tactical_plugin=INFO
 route_following_plugin=INFO
 pure_pursuit_wrapper=INFO
 system_controller=INFO

--- a/xil_carma_cloud/carma_rosconsole.conf
+++ b/xil_carma_cloud/carma_rosconsole.conf
@@ -1,26 +1,44 @@
 # Set the default ros output level
-log4j.logger.ros=WARN
-log4j.logger.ros.roscpp.superdebug=WARN
+ros=WARN
+roscpp.superdebug=WARN
 
 # Set package specific log level
-# Syntax is log4j.logger.ros.< my package name>=< Log level>
+# Syntax is <my package name>=< Log level>
 # Log levels
 # DEBUG	Detailed logs useful for debugging
 # INFO	Useful logs for understanding system events
 # WARN	Warning notifications that represent problems but will not severly degrade system operation
 # ERROR	Error notifications that severly degrade system operation, but the system might still be able to operate
 # FATAL	Error notification that the system cannot recover from
-log4j.logger.ros.mpc_follower=INFO
-log4j.logger.ros.as=WARN
-log4j.logger.ros.waypoint_generator=INFO
-log4j.logger.ros.route=INFO
-log4j.logger.ros.mpc_follower_wrapper=INFO
-log4j.logger.ros.carma_wm=INFO
-log4j.logger.ros.arbitrator=WARN
-log4j.logger.ros.trajectory_executor=INFO
-log4j.logger.ros.plan_delegator=WARN
-log4j.logger.ros.inlanecruising_plugin=INFO
-log4j.logger.ros.route_following_plugin=INFO
-log4j.logger.ros.pure_pursuit_wrapper=INFO
-log4j.logger.ros.system_controller=INFO
-log4j.logger.ros.subsystem_controllers=INFO
+#
+# Advanced usage notes:
+# * Both the node name or the dot separated, full namespace name works:
+#   - yield_plugin=DEBUG
+#   - guidance.plugins.yield_plugin=DEBUG
+# * Library loggers also work (which applies to all plugins that link to that library):
+#   - carma_wm=DEBUG
+#   - basic_autonomy=DEBUG
+# * Library loggers can also be scoped to a specific plugin (which applies to only that plugin):
+#   - yield_plugin.carma_wm=DEBUG
+#   ... would only affect the yield_plugin's carma_wm logger, not any other plugin's carma_wm.
+# * A node's own level cascades to its child loggers (yield_plugin=DEBUG also
+#   raises yield_plugin.carma_wm) unless a more specific key overrides it.
+# * A key that doesn't exactly match a real logger name (wrong namespace,
+#   typo, wrong pluralization) fails silently -- no error is printed.
+# * Changes here require restarting the affected process(es) -- levels are
+#   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
+
+mpc_follower=INFO
+as=WARN
+waypoint_generator=INFO
+route=INFO
+mpc_follower_wrapper=INFO
+carma_wm=INFO
+arbitrator=WARN
+trajectory_executor=INFO
+plan_delegator=WARN
+inlanecruising_plugin=INFO
+route_following_plugin=INFO
+pure_pursuit_wrapper=INFO
+system_controller=INFO
+subsystem_controllers=INFO

--- a/xil_carma_messenger/carma_rosconsole.conf
+++ b/xil_carma_messenger/carma_rosconsole.conf
@@ -3,7 +3,7 @@ ros=WARN
 roscpp.superdebug=WARN
 
 # Set package specific log level
-# Syntax is <my package name>=< Log level>
+# Syntax is <my node name>=< Log level>
 # Log levels
 # DEBUG	Detailed logs useful for debugging
 # INFO	Useful logs for understanding system events
@@ -28,16 +28,17 @@ roscpp.superdebug=WARN
 # * Changes here require restarting the affected process(es) -- levels are
 #   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
 
-mpc_follower=INFO
 as=WARN
-waypoint_generator=INFO
-route=INFO
-mpc_follower_wrapper=INFO
+route_node=INFO
 carma_wm=INFO
+basic_autonomy=WARN
 arbitrator=WARN
-trajectory_executor=INFO
+trajectory_executor_node=INFO
 plan_delegator=WARN
 inlanecruising_plugin=INFO
+cooperative_lanechange=INFO
+lci_strategic_plugin=INFO
+light_controlled_intersection_tactical_plugin=INFO
 route_following_plugin=INFO
 pure_pursuit_wrapper=INFO
 system_controller=INFO

--- a/xil_carma_messenger/carma_rosconsole.conf
+++ b/xil_carma_messenger/carma_rosconsole.conf
@@ -1,26 +1,44 @@
 # Set the default ros output level
-log4j.logger.ros=WARN
-log4j.logger.ros.roscpp.superdebug=WARN
+ros=WARN
+roscpp.superdebug=WARN
 
 # Set package specific log level
-# Syntax is log4j.logger.ros.< my package name>=< Log level>
+# Syntax is <my package name>=< Log level>
 # Log levels
 # DEBUG	Detailed logs useful for debugging
 # INFO	Useful logs for understanding system events
 # WARN	Warning notifications that represent problems but will not severly degrade system operation
 # ERROR	Error notifications that severly degrade system operation, but the system might still be able to operate
 # FATAL	Error notification that the system cannot recover from
-log4j.logger.ros.mpc_follower=INFO
-log4j.logger.ros.as=WARN
-log4j.logger.ros.waypoint_generator=INFO
-log4j.logger.ros.route=INFO
-log4j.logger.ros.mpc_follower_wrapper=INFO
-log4j.logger.ros.carma_wm=INFO
-log4j.logger.ros.arbitrator=WARN
-log4j.logger.ros.trajectory_executor=INFO
-log4j.logger.ros.plan_delegator=WARN
-log4j.logger.ros.inlanecruising_plugin=INFO
-log4j.logger.ros.route_following_plugin=INFO
-log4j.logger.ros.pure_pursuit_wrapper=INFO
-log4j.logger.ros.system_controller=INFO
-log4j.logger.ros.subsystem_controllers=INFO
+#
+# Advanced usage notes:
+# * Both the node name or the dot separated, full namespace name works:
+#   - yield_plugin=DEBUG
+#   - guidance.plugins.yield_plugin=DEBUG
+# * Library loggers also work (which applies to all plugins that link to that library):
+#   - carma_wm=DEBUG
+#   - basic_autonomy=DEBUG
+# * Library loggers can also be scoped to a specific plugin (which applies to only that plugin):
+#   - yield_plugin.carma_wm=DEBUG
+#   ... would only affect the yield_plugin's carma_wm logger, not any other plugin's carma_wm.
+# * A node's own level cascades to its child loggers (yield_plugin=DEBUG also
+#   raises yield_plugin.carma_wm) unless a more specific key overrides it.
+# * A key that doesn't exactly match a real logger name (wrong namespace,
+#   typo, wrong pluralization) fails silently -- no error is printed.
+# * Changes here require restarting the affected process(es) -- levels are
+#   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
+
+mpc_follower=INFO
+as=WARN
+waypoint_generator=INFO
+route=INFO
+mpc_follower_wrapper=INFO
+carma_wm=INFO
+arbitrator=WARN
+trajectory_executor=INFO
+plan_delegator=WARN
+inlanecruising_plugin=INFO
+route_following_plugin=INFO
+pure_pursuit_wrapper=INFO
+system_controller=INFO
+subsystem_controllers=INFO

--- a/xil_carma_training/carma_rosconsole.conf
+++ b/xil_carma_training/carma_rosconsole.conf
@@ -3,7 +3,7 @@ ros=WARN
 roscpp.superdebug=WARN
 
 # Set package specific log level
-# Syntax is <my package name>=< Log level>
+# Syntax is <my node name>=< Log level>
 # Log levels
 # DEBUG	Detailed logs useful for debugging
 # INFO	Useful logs for understanding system events
@@ -28,16 +28,17 @@ roscpp.superdebug=WARN
 # * Changes here require restarting the affected process(es) -- levels are
 #   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
 
-mpc_follower=INFO
 as=WARN
-waypoint_generator=INFO
-route=INFO
-mpc_follower_wrapper=INFO
+route_node=INFO
 carma_wm=INFO
+basic_autonomy=WARN
 arbitrator=WARN
-trajectory_executor=INFO
+trajectory_executor_node=INFO
 plan_delegator=WARN
 inlanecruising_plugin=INFO
+cooperative_lanechange=INFO
+lci_strategic_plugin=INFO
+light_controlled_intersection_tactical_plugin=INFO
 route_following_plugin=INFO
 pure_pursuit_wrapper=INFO
 system_controller=INFO

--- a/xil_carma_training/carma_rosconsole.conf
+++ b/xil_carma_training/carma_rosconsole.conf
@@ -1,26 +1,44 @@
 # Set the default ros output level
-log4j.logger.ros=WARN
-log4j.logger.ros.roscpp.superdebug=WARN
+ros=WARN
+roscpp.superdebug=WARN
 
 # Set package specific log level
-# Syntax is log4j.logger.ros.< my package name>=< Log level>
+# Syntax is <my package name>=< Log level>
 # Log levels
 # DEBUG	Detailed logs useful for debugging
 # INFO	Useful logs for understanding system events
 # WARN	Warning notifications that represent problems but will not severly degrade system operation
 # ERROR	Error notifications that severly degrade system operation, but the system might still be able to operate
 # FATAL	Error notification that the system cannot recover from
-log4j.logger.ros.mpc_follower=INFO
-log4j.logger.ros.as=WARN
-log4j.logger.ros.waypoint_generator=INFO
-log4j.logger.ros.route=INFO
-log4j.logger.ros.mpc_follower_wrapper=INFO
-log4j.logger.ros.carma_wm=INFO
-log4j.logger.ros.arbitrator=WARN
-log4j.logger.ros.trajectory_executor=INFO
-log4j.logger.ros.plan_delegator=WARN
-log4j.logger.ros.inlanecruising_plugin=INFO
-log4j.logger.ros.route_following_plugin=INFO
-log4j.logger.ros.pure_pursuit_wrapper=INFO
-log4j.logger.ros.system_controller=INFO
-log4j.logger.ros.subsystem_controllers=INFO
+#
+# Advanced usage notes:
+# * Both the node name or the dot separated, full namespace name works:
+#   - yield_plugin=DEBUG
+#   - guidance.plugins.yield_plugin=DEBUG
+# * Library loggers also work (which applies to all plugins that link to that library):
+#   - carma_wm=DEBUG
+#   - basic_autonomy=DEBUG
+# * Library loggers can also be scoped to a specific plugin (which applies to only that plugin):
+#   - yield_plugin.carma_wm=DEBUG
+#   ... would only affect the yield_plugin's carma_wm logger, not any other plugin's carma_wm.
+# * A node's own level cascades to its child loggers (yield_plugin=DEBUG also
+#   raises yield_plugin.carma_wm) unless a more specific key overrides it.
+# * A key that doesn't exactly match a real logger name (wrong namespace,
+#   typo, wrong pluralization) fails silently -- no error is printed.
+# * Changes here require restarting the affected process(es) -- levels are
+#   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
+
+mpc_follower=INFO
+as=WARN
+waypoint_generator=INFO
+route=INFO
+mpc_follower_wrapper=INFO
+carma_wm=INFO
+arbitrator=WARN
+trajectory_executor=INFO
+plan_delegator=WARN
+inlanecruising_plugin=INFO
+route_following_plugin=INFO
+pure_pursuit_wrapper=INFO
+system_controller=INFO
+subsystem_controllers=INFO

--- a/xil_cloud_telematics/carma_rosconsole.conf
+++ b/xil_cloud_telematics/carma_rosconsole.conf
@@ -3,7 +3,7 @@ ros=WARN
 roscpp.superdebug=WARN
 
 # Set package specific log level
-# Syntax is <my package name>=< Log level>
+# Syntax is <my node name>=< Log level>
 # Log levels
 # DEBUG	Detailed logs useful for debugging
 # INFO	Useful logs for understanding system events
@@ -28,16 +28,17 @@ roscpp.superdebug=WARN
 # * Changes here require restarting the affected process(es) -- levels are
 #   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
 
-mpc_follower=INFO
 as=WARN
-waypoint_generator=INFO
-route=INFO
-mpc_follower_wrapper=INFO
+route_node=INFO
 carma_wm=INFO
+basic_autonomy=WARN
 arbitrator=WARN
-trajectory_executor=INFO
+trajectory_executor_node=INFO
 plan_delegator=WARN
 inlanecruising_plugin=INFO
+cooperative_lanechange=INFO
+lci_strategic_plugin=INFO
+light_controlled_intersection_tactical_plugin=INFO
 route_following_plugin=INFO
 pure_pursuit_wrapper=INFO
 system_controller=INFO

--- a/xil_cloud_telematics/carma_rosconsole.conf
+++ b/xil_cloud_telematics/carma_rosconsole.conf
@@ -1,26 +1,44 @@
 # Set the default ros output level
-log4j.logger.ros=WARN
-log4j.logger.ros.roscpp.superdebug=WARN
+ros=WARN
+roscpp.superdebug=WARN
 
 # Set package specific log level
-# Syntax is log4j.logger.ros.< my package name>=< Log level>
+# Syntax is <my package name>=< Log level>
 # Log levels
 # DEBUG	Detailed logs useful for debugging
 # INFO	Useful logs for understanding system events
 # WARN	Warning notifications that represent problems but will not severly degrade system operation
 # ERROR	Error notifications that severly degrade system operation, but the system might still be able to operate
 # FATAL	Error notification that the system cannot recover from
-log4j.logger.ros.mpc_follower=INFO
-log4j.logger.ros.as=WARN
-log4j.logger.ros.waypoint_generator=INFO
-log4j.logger.ros.route=INFO
-log4j.logger.ros.mpc_follower_wrapper=INFO
-log4j.logger.ros.carma_wm=INFO
-log4j.logger.ros.arbitrator=WARN
-log4j.logger.ros.trajectory_executor=INFO
-log4j.logger.ros.plan_delegator=WARN
-log4j.logger.ros.inlanecruising_plugin=INFO
-log4j.logger.ros.route_following_plugin=INFO
-log4j.logger.ros.pure_pursuit_wrapper=INFO
-log4j.logger.ros.system_controller=INFO
-log4j.logger.ros.subsystem_controllers=INFO
+#
+# Advanced usage notes:
+# * Both the node name or the dot separated, full namespace name works:
+#   - yield_plugin=DEBUG
+#   - guidance.plugins.yield_plugin=DEBUG
+# * Library loggers also work (which applies to all plugins that link to that library):
+#   - carma_wm=DEBUG
+#   - basic_autonomy=DEBUG
+# * Library loggers can also be scoped to a specific plugin (which applies to only that plugin):
+#   - yield_plugin.carma_wm=DEBUG
+#   ... would only affect the yield_plugin's carma_wm logger, not any other plugin's carma_wm.
+# * A node's own level cascades to its child loggers (yield_plugin=DEBUG also
+#   raises yield_plugin.carma_wm) unless a more specific key overrides it.
+# * A key that doesn't exactly match a real logger name (wrong namespace,
+#   typo, wrong pluralization) fails silently -- no error is printed.
+# * Changes here require restarting the affected process(es) -- levels are
+#   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
+
+mpc_follower=INFO
+as=WARN
+waypoint_generator=INFO
+route=INFO
+mpc_follower_wrapper=INFO
+carma_wm=INFO
+arbitrator=WARN
+trajectory_executor=INFO
+plan_delegator=WARN
+inlanecruising_plugin=INFO
+route_following_plugin=INFO
+pure_pursuit_wrapper=INFO
+system_controller=INFO
+subsystem_controllers=INFO

--- a/xil_vru_uc1_scenario/carma_rosconsole.conf
+++ b/xil_vru_uc1_scenario/carma_rosconsole.conf
@@ -3,7 +3,7 @@ ros=WARN
 roscpp.superdebug=WARN
 
 # Set package specific log level
-# Syntax is <my package name>=< Log level>
+# Syntax is <my node name>=< Log level>
 # Log levels
 # DEBUG	Detailed logs useful for debugging
 # INFO	Useful logs for understanding system events
@@ -28,16 +28,17 @@ roscpp.superdebug=WARN
 # * Changes here require restarting the affected process(es) -- levels are
 #   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
 
-mpc_follower=INFO
 as=WARN
-waypoint_generator=INFO
-route=INFO
-mpc_follower_wrapper=INFO
+route_node=INFO
 carma_wm=INFO
+basic_autonomy=WARN
 arbitrator=WARN
-trajectory_executor=INFO
+trajectory_executor_node=INFO
 plan_delegator=WARN
 inlanecruising_plugin=INFO
+cooperative_lanechange=INFO
+lci_strategic_plugin=INFO
+light_controlled_intersection_tactical_plugin=INFO
 route_following_plugin=INFO
 pure_pursuit_wrapper=INFO
 system_controller=INFO

--- a/xil_vru_uc1_scenario/carma_rosconsole.conf
+++ b/xil_vru_uc1_scenario/carma_rosconsole.conf
@@ -1,26 +1,44 @@
 # Set the default ros output level
-log4j.logger.ros=WARN
-log4j.logger.ros.roscpp.superdebug=WARN
+ros=WARN
+roscpp.superdebug=WARN
 
 # Set package specific log level
-# Syntax is log4j.logger.ros.< my package name>=< Log level>
+# Syntax is <my package name>=< Log level>
 # Log levels
 # DEBUG	Detailed logs useful for debugging
 # INFO	Useful logs for understanding system events
 # WARN	Warning notifications that represent problems but will not severly degrade system operation
 # ERROR	Error notifications that severly degrade system operation, but the system might still be able to operate
 # FATAL	Error notification that the system cannot recover from
-log4j.logger.ros.mpc_follower=INFO
-log4j.logger.ros.as=WARN
-log4j.logger.ros.waypoint_generator=INFO
-log4j.logger.ros.route=INFO
-log4j.logger.ros.mpc_follower_wrapper=INFO
-log4j.logger.ros.carma_wm=INFO
-log4j.logger.ros.arbitrator=WARN
-log4j.logger.ros.trajectory_executor=INFO
-log4j.logger.ros.plan_delegator=WARN
-log4j.logger.ros.inlanecruising_plugin=INFO
-log4j.logger.ros.route_following_plugin=INFO
-log4j.logger.ros.pure_pursuit_wrapper=INFO
-log4j.logger.ros.system_controller=INFO
-log4j.logger.ros.subsystem_controllers=INFO
+#
+# Advanced usage notes:
+# * Both the node name or the dot separated, full namespace name works:
+#   - yield_plugin=DEBUG
+#   - guidance.plugins.yield_plugin=DEBUG
+# * Library loggers also work (which applies to all plugins that link to that library):
+#   - carma_wm=DEBUG
+#   - basic_autonomy=DEBUG
+# * Library loggers can also be scoped to a specific plugin (which applies to only that plugin):
+#   - yield_plugin.carma_wm=DEBUG
+#   ... would only affect the yield_plugin's carma_wm logger, not any other plugin's carma_wm.
+# * A node's own level cascades to its child loggers (yield_plugin=DEBUG also
+#   raises yield_plugin.carma_wm) unless a more specific key overrides it.
+# * A key that doesn't exactly match a real logger name (wrong namespace,
+#   typo, wrong pluralization) fails silently -- no error is printed.
+# * Changes here require restarting the affected process(es) -- levels are
+#   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
+
+mpc_follower=INFO
+as=WARN
+waypoint_generator=INFO
+route=INFO
+mpc_follower_wrapper=INFO
+carma_wm=INFO
+arbitrator=WARN
+trajectory_executor=INFO
+plan_delegator=WARN
+inlanecruising_plugin=INFO
+route_following_plugin=INFO
+pure_pursuit_wrapper=INFO
+system_controller=INFO
+subsystem_controllers=INFO


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Supports https://github.com/usdot-fhwa-stol/carma-utils/pull/260
Now the carma-config is using the new paradigm of log level setting
<!--- Describe your changes in detail -->

## Related Issue
See above
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://usdot-carma.atlassian.net/browse/HASS-680
## Motivation and Context
The logging functionality has been long broken for the library code.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Local integration tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.